### PR TITLE
Lazily create module.[[ImportMeta]] object

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -127,112 +127,6 @@ contributors: Domenic Denicola
         </table>
       </emu-table>
     </emu-clause>
-
-    <emu-clause id="sec-source-text-module-records">
-      <h1>Source Text Module Records</h1>
-
-      <emu-clause id="sec-moduledeclarationinstantiation">
-        <h1>Instantiate( ) Concrete Method</h1>
-
-        <emu-clause id="sec-innermoduledeclarationinstantiation" aoid="InnerModuleDeclarationInstantiation">
-          <h1>InnerModuleDeclarationInstantiation( _module_, _stack_, _index_ )</h1>
-
-          <p>The InnerModuleDeclarationInstantiation abstract operation is used by Instantiate to perform the actual instantiation process for the Source Text Module Record _module_, as well as recursively on all other Source Text Module Records in the dependency graph. The _stack_ and _index_ parameters, as well as a module's [[DFSIndex]] and [[DFSAncestorIndex]] fields, keep track of the depth-first search (DFS) traversal. In particular, [[DFSAncestorIndex]] is used to discover strongly connected components (SCCs), such that all modules in an SCC transition to `"instantiated"` together.</p>
-
-          <p>This abstract operation performs the following steps:</p>
-
-          <emu-alg>
-            1. If _module_ is not a Source Text Module Record, then
-              1. Assert: _module_.[[Status]] is not `"instantiating"`.
-              1. Perform ? _module_.Instantiate().
-              1. Return _index_.
-            1. If _module_.[[Status]] is `"instantiating"`, `"instantiated"`, or `"evaluated"`, then
-              1. Return _index_.
-            1. If _module_.[[Status]] is `"errored"`, then
-              1. Return _module_.[[ErrorCompletion]].
-            1. Assert: _module_.[[Status]] is `"uninstantiated"`.
-            1. Set _module_.[[Status]] to `"instantiating"`.
-            1. Set _module_.[[DFSIndex]] to _index_.
-            1. Set _module_.[[DFSAncestorIndex]] to _index_.
-            1. Set _index_ to _index_ + 1.
-            1. Append _module_ to _stack_.
-            1. For each String _required_ that is an element of _module_.[[RequestedModules]], do
-              1. Let _requiredModule_ be ? HostResolveImportedModule(_module_, _required_).
-              1. Set _index_ to ? InnerModuleDeclarationInstantiation(_requiredModule_, _stack_, _index_).
-              1. Assert: _requiredModule_.[[Status]] is either `"instantiating"`, `"instantiated"`, or `"evaluated"`.
-              1. Assert: _requiredModule_.[[Status]] is `"instantiating"` if and only if _requiredModule_ is in _stack_.
-              1. If _requiredModule_.[[Status]] is `"instantiating"`, then
-                1. Assert: _requiredModule_ is a Source Text Module Record.
-                1. Set _module_.[[DFSAncestorIndex]] to min(_module_.[[DFSAncestorIndex]], _requiredModule_.[[DFSAncestorIndex]]).
-            1. Perform ? ModuleDeclarationEnvironmentSetup(_module_).
-            1. <ins>Let _importMeta_ be ObjectCreate(*null*).</ins>
-            1. <ins>Let _importMetaValues_ be ! HostGetImportMetaProperties(_module_).</ins>
-            1. <ins>For each Record {[[Key]], [[Value]]} _p_ that is an element of _importMetaValues_,</ins>
-              1. <ins>Perform ! CreateDataProperty(_importMeta_, _p_.[[Key]], _p_.[[Value]]).</ins>
-            1. <ins>Perform ! HostFinalizeImportMeta(_importMeta_, _module_).</ins>
-            1. <ins>Set _module_.[[ImportMeta]] to _importMeta_.</ins>
-            1. Assert: _module_ occurs exactly once in _stack_.
-            1. Assert: _module_.[[DFSAncestorIndex]] is less than or equal to _module_.[[DFSIndex]].
-            1. If _module_.[[DFSAncestorIndex]] equals _module_.[[DFSIndex]], then
-              1. Let _done_ be *false*.
-              1. Repeat, while _done_ is *false*,
-                1. Let _requiredModule_ be the last element in _stack_.
-                1. Remove the last element of _stack_.
-                1. Set _requiredModule_.[[Status]] to `"instantiated"`.
-                1. If _requiredModule_ and _module_ are the same Module Record, set _done_ to *true*.
-            1. Return _index_.
-          </emu-alg>
-        </emu-clause>
-      </emu-clause>
-
-      <emu-clause id="sec-hostgetimportmetaproperties" aoid="HostGetImportMetaProperties">
-        <h1><ins>Runtime Semantics: HostGetImportMetaProperties ( _moduleRecord_ )</ins></h1>
-
-        <p>HostGetImportMetaProperties is an implementation-defined abstract operation that allows
-        hosts to provide property keys and values for the object returned from `import.meta`.</p>
-
-        <p>The implementation of HostGetImportMetaProperties must conform to the following
-        requirements:</p>
-
-        <ul>
-          <li>It must return a List, whose values are all Records with the two fields [[Key]] and
-          [[Value]].</li>
-
-          <li>Each such Record's [[Key]] field must be a property key, i.e., IsPropertyKey must
-          return true when applied to it.</li>
-
-          <li>Each such Record's [[Value]] field must be an ECMAScript value.</li>
-
-          <li>It must always complete normally (i.e., not return an abrupt completion).</li>
-        </ul>
-
-        <p>The default implementation of HostGetImportMetaProperties is to return a new empty
-        List.</p>
-      </emu-clause>
-
-      <emu-clause id="sec-hostfinalizeimportmeta" aoid="HostFinalizeImportMeta">
-        <h1><ins>Runtime Semantics: HostFinalizeImportMeta ( _importMeta_, _moduleRecord_ )</ins></h1>
-
-        <p>HostFinalizeImportMeta is an implementation-defined abstract operation that allows
-        hosts to perform any extraordinary operations to prepare the object returned from
-        `import.meta`.</p>
-
-        <p>Most hosts will be able to simply define HostGetImportMetaProperties, and leave
-        HostFinalizeImportMeta with its default behavior. However, HostFinalizeImportMeta provies an
-        "escape hatch" for hosts which need to directly manipulate the object before it is exposed
-        to ECMAScript code.</p>
-
-        <p>The implementation of HostFinalizeImportMeta must conform to the following
-        requirements:</p>
-
-        <ul>
-          <li>It must always complete normally (i.e., not return an abrupt completion).</li>
-        </ul>
-
-        <p>The default implementation of HostFinalizeImportMeta is to do nothing.</p>
-      </emu-clause>
-    </emu-clause>
-  </emu-clause>
 </emu-clause>
 
 <emu-clause id="sec-left-hand-side-expressions">
@@ -369,9 +263,64 @@ contributors: Domenic Denicola
       1. <ins>Let _module_ be GetActiveScriptOrModule().</ins>
       1. <ins>Assert: _module_ is a Module Record (not a Script Record).</ins>
       1. <ins>Let _importMeta_ be _module_.[[ImportMeta]].</ins>
-      1. <ins>Assert: Type(_importMeta_) is Object.</ins>
-      1. <ins>Return _importMeta_.</ins>
+      1. <ins>If _importMeta_ is *undefined*.
+        1. <ins>Let _importMeta_ be ObjectCreate(*null*).</ins>
+        1. <ins>Let _importMetaValues_ be ! HostGetImportMetaProperties(_module_).</ins>
+        1. <ins>For each Record {[[Key]], [[Value]]} _p_ that is an element of _importMetaValues_,</ins>
+        1. <ins>Perform ! CreateDataProperty(_importMeta_, _p_.[[Key]], _p_.[[Value]]).</ins>
+        1. <ins>Perform ! HostFinalizeImportMeta(_importMeta_, _module_).</ins>
+        1. <ins>Set _module_.[[ImportMeta]] to _importMeta_.</ins>
+        1. <ins>Return _importMeta_.</ins>
+      1. <ins>Else,
+        1. <ins>Assert: Type(_importMeta_) is Object.</ins>
+        1. <ins>Return _importMeta_.</ins>
     </emu-alg>
-  </emu-clause>
+
+    <emu-clause id="sec-hostgetimportmetaproperties" aoid="HostGetImportMetaProperties">
+      <h1><ins>Runtime Semantics: HostGetImportMetaProperties ( _moduleRecord_ )</ins></h1>
+
+      <p>HostGetImportMetaProperties is an implementation-defined abstract operation that allows
+        hosts to provide property keys and values for the object returned from `import.meta`.</p>
+
+      <p>The implementation of HostGetImportMetaProperties must conform to the following
+        requirements:</p>
+
+      <ul>
+        <li>It must return a List, whose values are all Records with the two fields [[Key]] and
+          [[Value]].</li>
+
+        <li>Each such Record's [[Key]] field must be a property key, i.e., IsPropertyKey must
+          return true when applied to it.</li>
+
+        <li>Each such Record's [[Value]] field must be an ECMAScript value.</li>
+
+        <li>It must always complete normally (i.e., not return an abrupt completion).</li>
+      </ul>
+
+      <p>The default implementation of HostGetImportMetaProperties is to return a new empty
+        List.</p>
+    </emu-clause>
+
+    <emu-clause id="sec-hostfinalizeimportmeta" aoid="HostFinalizeImportMeta">
+      <h1><ins>Runtime Semantics: HostFinalizeImportMeta ( _importMeta_, _moduleRecord_ )</ins></h1>
+
+      <p>HostFinalizeImportMeta is an implementation-defined abstract operation that allows
+        hosts to perform any extraordinary operations to prepare the object returned from
+        `import.meta`.</p>
+
+      <p>Most hosts will be able to simply define HostGetImportMetaProperties, and leave
+        HostFinalizeImportMeta with its default behavior. However, HostFinalizeImportMeta provies an
+        "escape hatch" for hosts which need to directly manipulate the object before it is exposed
+        to ECMAScript code.</p>
+
+      <p>The implementation of HostFinalizeImportMeta must conform to the following
+        requirements:</p>
+
+      <ul>
+        <li>It must always complete normally (i.e., not return an abrupt completion).</li>
+      </ul>
+
+      <p>The default implementation of HostFinalizeImportMeta is to do nothing.</p>
+    </emu-clause>
   </emu-clause>
 </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -105,11 +105,9 @@ contributors: Domenic Denicola
             <td><ins>[[Meta]]</ins></td>
             <td><ins>Object | *undefined*</ins></td>
             <td>
-              <ins>An object exposed through the `import.meta` meta property. Concrete subclasses of
-              the Abstract Module Record specification type are expected to fill this field when
-              creating the Module Record, usually by delegating to the host environment. It is
-              *undefined* by default, but must become an Object before it is ever accessed by
-              ECMAScript code.</ins>
+              <ins>An object exposed through the `import.meta` meta property. It is *undefined* by
+              default, but will become an Object before it is ever accessed by ECMAScript
+              code.</ins>
             </td>
           </tr>
           <tr>
@@ -264,7 +262,7 @@ contributors: Domenic Denicola
       1. <ins>Assert: _module_ is a Module Record (not a Script Record).</ins>
       1. <ins>Let _importMeta_ be _module_.[[ImportMeta]].</ins>
       1. <ins>If _importMeta_ is *undefined*.
-        1. <ins>Let _importMeta_ be ObjectCreate(*null*).</ins>
+        1. <ins>Set _importMeta_ to ObjectCreate(*null*).</ins>
         1. <ins>Let _importMetaValues_ be ! HostGetImportMetaProperties(_module_).</ins>
         1. <ins>For each Record {[[Key]], [[Value]]} _p_ that is an element of _importMetaValues_,</ins>
         1. <ins>Perform ! CreateDataProperty(_importMeta_, _p_.[[Key]], _p_.[[Value]]).</ins>


### PR DESCRIPTION
Previously, this object was created on every module
instantiation. Instead, this patch lazily creates the object only when
import.meta is used.

The previous behavior was not observable to JavaScript, but was
observable through the embedding API.